### PR TITLE
Fix finish time to be the finish time instead of the start time

### DIFF
--- a/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
+++ b/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
@@ -20,7 +20,7 @@ public class BuildDAO {
                 (build.getTimer().getStartTime(), ZoneId.of(build.getTimer().getTimeZoneId()));
 
         OffsetDateTime finish = OffsetDateTime.ofInstant
-                (build.getTimer().getStartTime(), ZoneId.of(build.getTimer().getTimeZoneId()));
+                (build.getTimer().getFinishTime(), ZoneId.of(build.getTimer().getTimeZoneId()));
 
         Object[] params = new Object[] {
                 build.getBuildId(),


### PR DESCRIPTION
Standard Copy & Paste error
Hadn't noticed it before as I had mostly focused on analyzing timing at the task, rather than build, level