### PR TITLE
Skip build if already in Build table.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ run {
 
     if (System.getProperty('debug') != null) {
         jvmArgs '-Xdebug',
-                '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+                '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5006'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,10 @@ mainClassName = 'com.gradle.exportapi.Application'
 run {
     /* Pass all the properties to the application java process*/
     systemProperties System.getProperties()
+
+    if (System.getProperty('debug') != null) {
+        jvmArgs '-Xdebug',
+                '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+    }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,4 +4,3 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
-#distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-2-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-2-bin.zip

--- a/src/main/java/com/gradle/exportapi/Application.java
+++ b/src/main/java/com/gradle/exportapi/Application.java
@@ -141,7 +141,7 @@ final class Application {
         return request
                 .flatMap(HttpClientResponse::getContentAsServerSentEvents)
                 .doOnNext(serverSentEvent -> _lastBuildEventId.set(serverSentEvent.getEventIdAsString()))
-                .doOnSubscribe(() -> log.info("Streaming events for : " + buildId))
+                .doOnSubscribe(() -> log.info("Streaming events for build: " + buildId))
                 .filter(serverSentEvent -> serverSentEvent.getEventTypeAsString().equals("BuildEvent"))
                 .map(Application::parse)
                 .onErrorResumeNext(t -> {

--- a/src/main/java/com/gradle/exportapi/EventProcessor.java
+++ b/src/main/java/com/gradle/exportapi/EventProcessor.java
@@ -218,7 +218,8 @@ data: {"timestamp":1491615409161,"type":{"majorVersion":1,"minorVersion":0,"even
         Build currentBuild = processor.currentBuild;
         currentBuild.resolveStatus();
 
-        currentBuild.setId( insertBuild(currentBuild) );
+        currentBuild.setId( insertOrGetBuild(currentBuild) );
+
 
         currentBuild.taskMap.values().stream().forEach( TasksDAO::insertTask );
         currentBuild.testMap.values().stream().forEach( TestsDAO::insertTest );

--- a/src/main/java/com/gradle/exportapi/EventProcessor.java
+++ b/src/main/java/com/gradle/exportapi/EventProcessor.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.gradle.exportapi.dao.TasksDAO;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import static com.gradle.exportapi.dao.BuildDAO.*;
 
@@ -218,7 +219,12 @@ data: {"timestamp":1491615409161,"type":{"majorVersion":1,"minorVersion":0,"even
         Build currentBuild = processor.currentBuild;
         currentBuild.resolveStatus();
 
-        currentBuild.setId( insertOrGetBuild(currentBuild) );
+        Optional<Long> buildTableId = getBuildTableId(currentBuild);
+        if (!buildTableId.isPresent()) {
+            log.warn(String.format("%s already in db. Skipped. This could entail an incomplete export", currentBuild.getBuildId()));
+            return;
+        }
+        currentBuild.setId( insertBuild(currentBuild) );
 
 
         currentBuild.taskMap.values().stream().forEach( TasksDAO::insertTask );

--- a/src/main/java/com/gradle/exportapi/EventProcessor.java
+++ b/src/main/java/com/gradle/exportapi/EventProcessor.java
@@ -220,8 +220,7 @@ data: {"timestamp":1491615409161,"type":{"majorVersion":1,"minorVersion":0,"even
 
         Optional<Long> buildTableId = BuildDAO.getBuildTableId(currentBuild);
         if (buildTableId.isPresent()) {
-            log.warn(String.format("Skipped build %s that is already in db. This could entail an incomplete export from previous run.",
-                    currentBuild.getBuildId()));
+            log.warn("Skipped build {} that is already in db", currentBuild.getBuildId());
             return;
         }
         currentBuild.setId(BuildDAO.insertBuild(currentBuild));

--- a/src/main/java/com/gradle/exportapi/EventProcessor.java
+++ b/src/main/java/com/gradle/exportapi/EventProcessor.java
@@ -220,15 +220,16 @@ data: {"timestamp":1491615409161,"type":{"majorVersion":1,"minorVersion":0,"even
         currentBuild.resolveStatus();
 
         Optional<Long> buildTableId = getBuildTableId(currentBuild);
-        if (!buildTableId.isPresent()) {
-            log.warn(String.format("%s already in db. Skipped. This could entail an incomplete export", currentBuild.getBuildId()));
+        if (buildTableId.isPresent()) {
+            log.warn(String.format("Skipped build %s that is already in db. This could entail an incomplete export from previous run.",
+                    currentBuild.getBuildId()));
             return;
         }
-        currentBuild.setId( insertBuild(currentBuild) );
+        currentBuild.setId(insertBuild(currentBuild));
 
 
-        currentBuild.taskMap.values().stream().forEach( TasksDAO::insertTask );
-        currentBuild.testMap.values().stream().forEach( TestsDAO::insertTest );
+        currentBuild.taskMap.values().stream().forEach(TasksDAO::insertTask);
+        currentBuild.testMap.values().stream().forEach(TestsDAO::insertTest);
         currentBuild.customValues.stream().forEach(CustomValueDAO::insertCustomValue);
     }
 

--- a/src/main/java/com/gradle/exportapi/EventProcessor.java
+++ b/src/main/java/com/gradle/exportapi/EventProcessor.java
@@ -1,17 +1,16 @@
 package com.gradle.exportapi;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.gradle.exportapi.dao.BuildDAO;
 import com.gradle.exportapi.dao.CustomValueDAO;
+import com.gradle.exportapi.dao.TasksDAO;
 import com.gradle.exportapi.dao.TestsDAO;
 import com.gradle.exportapi.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.gradle.exportapi.dao.TasksDAO;
 
 import java.time.Instant;
 import java.util.Optional;
-
-import static com.gradle.exportapi.dao.BuildDAO.*;
 
 
 class EventProcessor {
@@ -219,13 +218,13 @@ data: {"timestamp":1491615409161,"type":{"majorVersion":1,"minorVersion":0,"even
         Build currentBuild = processor.currentBuild;
         currentBuild.resolveStatus();
 
-        Optional<Long> buildTableId = getBuildTableId(currentBuild);
+        Optional<Long> buildTableId = BuildDAO.getBuildTableId(currentBuild);
         if (buildTableId.isPresent()) {
             log.warn(String.format("Skipped build %s that is already in db. This could entail an incomplete export from previous run.",
                     currentBuild.getBuildId()));
             return;
         }
-        currentBuild.setId(insertBuild(currentBuild));
+        currentBuild.setId(BuildDAO.insertBuild(currentBuild));
 
 
         currentBuild.taskMap.values().stream().forEach(TasksDAO::insertTask);

--- a/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
+++ b/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
@@ -1,5 +1,6 @@
 package com.gradle.exportapi.dao;
 
+import com.gradle.exportapi.dbutil.SQLHelper;
 import com.gradle.exportapi.model.Build;
 import org.knowm.yank.Yank;
 import org.slf4j.Logger;
@@ -8,11 +9,9 @@ import org.slf4j.LoggerFactory;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 
-import static com.gradle.exportapi.dbutil.SQLHelper;
-
 public class BuildDAO {
 
-    static final Logger log = LoggerFactory.getLogger(BuildDAO.class);
+    private static final Logger logger = LoggerFactory.getLogger(BuildDAO.class);
 
     /**
      * Insert the build if the db does not have it, else get the existing one.
@@ -42,6 +41,7 @@ public class BuildDAO {
         // If build id exists in the builds table, return the id directly
         Long id = Yank.queryScalar("SELECT id FROM builds WHERE build_id = ?", Long.class, new Object[]{build.getBuildId()});
         if (id != null) {
+            logger.warn(String.format("%s already in db. Skipped. This could entail an incomplete export", build.getBuildId()));
             return id;
         }
 

--- a/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
+++ b/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
@@ -34,8 +34,7 @@ public class BuildDAO {
 
 
         // If build id exists in the builds table, return the id directly
-        String getIdSql = "SELECT id FROM builds WHERE build_id = ?";
-        Long id = Yank.queryScalar(getIdSql, Long.class, new Object[] {build.getBuildId()});
+        Long id = Yank.queryScalar("SELECT id FROM builds WHERE build_id = ?", Long.class, new Object[] {build.getBuildId()});
         if (id != null) {
             return id;
         }

--- a/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
+++ b/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
@@ -14,12 +14,6 @@ public class BuildDAO {
 
     private static final Logger log = LoggerFactory.getLogger(BuildDAO.class);
 
-    /**
-     * Insert the build if the db does not have it, else get the existing one.
-     *
-     * @param build a build.
-     * @return the id of the build in the `builds` table.
-     */
     public static long insertBuild(Build build) {
 
         OffsetDateTime start = OffsetDateTime.ofInstant

--- a/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
+++ b/src/main/java/com/gradle/exportapi/dao/BuildDAO.java
@@ -32,12 +32,20 @@ public class BuildDAO {
                 build.getTagsAsSingleString()
         };
 
+
+        // If build id exists in the builds table, return the id directly
+        String getIdSql = "SELECT id FROM builds WHERE build_id = ?";
+        Long id = Yank.queryScalar(getIdSql, Long.class, new Object[] {build.getBuildId()});
+        if (id != null) {
+            return id;
+        }
+
         String SQL = insert("builds (build_id, user_name, root_project_name, start, finish, status, tags)", params);
-        Long generatedid= Yank.insert(SQL, params);
-        if(generatedid == 0) {
+        Long generatedId= Yank.insert(SQL, params);
+        if(generatedId == 0) {
             throw new RuntimeException("Unable to save build record for " + build.getBuildId());
         }
-        return generatedid;
+        return generatedId;
     }
 
     public static String findLastBuildId() {


### PR DESCRIPTION
Other minor changes:
* Upgrade gradle to 4.0
* Add `-Ddebug` feature to allow remote debug
* Some formatting

Example output:
```
15:36:35.195 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: 4c32yszglioy2
15:36:35.197 [main] WARN  com.gradle.exportapi.EventProcessor - Skipped build serztqtpey5p4 that is already in db. This could entail an incomplete export from previous run.
15:36:35.635 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: xdmq4ogb2mbse
15:36:35.637 [main] WARN  com.gradle.exportapi.EventProcessor - Skipped build 4c32yszglioy2 that is already in db. This could entail an incomplete export from previous run.
15:36:36.098 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: ajoq3jfhqyzy4
15:36:36.132 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: nhqorurbh6oaq
15:36:36.486 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: 3toy7kah4nxyi
15:36:36.518 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: tabv2hvssopka
15:36:36.552 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: 6ltqlmgylumao
15:36:36.585 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: 7qq2wu5g574mw
15:36:36.620 [rxnetty-nio-eventloop-1-1] INFO  com.gradle.exportapi.Application - Streaming events for build: s6nwmx4vllgli
```